### PR TITLE
two bugfixes:

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "lincanbin/white-html-filter",
+    "name": "jizuscreed/white-html-filter",
     "keywords": [
         "xss",
         "filter",
         "html",
         "whitelist"
     ],
-    "description": "A lightweight php-based HTML tag and attribute whitelist filter.",
+    "description": "A lightweight php-based HTML tag and attribute whitelist filter. Fork of lincanbin/white-html-filter with two critical bugfixes",
     "license": "Apache-2.0",
     "authors": [
         {

--- a/src/WhiteHTMLFilter.php
+++ b/src/WhiteHTMLFilter.php
@@ -203,7 +203,7 @@ class WhiteHTMLFilter
             $attrName = strtolower($domAttr->name);
             $attrValue = $domAttr->value;
             // 如果不在白名单attr中，而且允许data-*，且不是data-*，则删除
-            if (!in_array($attrName, $attributesWhiteList) && $allowDataAttribute && (stripos($attrName, "data-") !== 0)) {
+            if (!in_array($attrName, $attributesWhiteList) && (!$allowDataAttribute || stripos($attrName, "data-") === false)) {
                 $elem->removeAttribute($attrName);
             } else {
                 if (isset($attributesFilterMap[$attrName])) {


### PR DESCRIPTION
Hello! Thank you for you repo, it was very usefull for me. But I noticed two bugs (in one string ;-) ) and fixed it. Please, accept it:

1) wrong and/or logic between exact match and math with wildcard (there was no removing attributes without $allowDataAttribute == true)
2) stripos() !== 0 - was completelly wrong, because match with start of string will return exactly 0. We need to strict compare with false (I replaced !== with === because of the first bugfix)